### PR TITLE
remove post logic as this action doesn't have any

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,4 +49,3 @@ outputs:
 runs:
   using: "node20"
   main: "dist/index.js"
-  post: "dist/index.js"


### PR DESCRIPTION
This Action currently does not have any `post` run logic so this duplicate code execution should be removed.
